### PR TITLE
Fix some compiler errors in bevy_easings

### DIFF
--- a/bevy_easings/src/implemented.rs
+++ b/bevy_easings/src/implemented.rs
@@ -122,10 +122,10 @@ impl Lerp for EaseValue<Val> {
     fn lerp(&self, other: &Self, scalar: &Self::Scalar) -> Self {
         match (self.0, other.0) {
             (Val::Percent(self_val), Val::Percent(other_val)) => {
-                EaseValue(Val::Percent(self_val.lerp(&other_val, scalar)))
+                EaseValue(Val::Percent(self_val.lerp(other_val, *scalar)))
             }
             (Val::Px(self_val), Val::Px(other_val)) => {
-                EaseValue(Val::Px(self_val.lerp(&other_val, scalar)))
+                EaseValue(Val::Px(self_val.lerp(other_val, *scalar)))
             }
             _ => EaseValue(self.0),
         }

--- a/bevy_easings/src/lib.rs
+++ b/bevy_easings/src/lib.rs
@@ -4,12 +4,11 @@
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
-    unstable_features,
     unused_import_braces,
     unused_qualifications,
     missing_docs
 )]
-
+#![feature(float_interpolation)]
 //! Ease plugin for Bevy
 
 use std::time::Duration;


### PR DESCRIPTION
Adding the plugin to `cargo.toml ` would cause the project to not compile, now it does.