### PR TITLE
fix compilation on rust 1.55 stable and nightly

### DIFF
--- a/bevy_easings/src/implemented.rs
+++ b/bevy_easings/src/implemented.rs
@@ -122,10 +122,10 @@ impl Lerp for EaseValue<Val> {
     fn lerp(&self, other: &Self, scalar: &Self::Scalar) -> Self {
         match (self.0, other.0) {
             (Val::Percent(self_val), Val::Percent(other_val)) => {
-                EaseValue(Val::Percent(self_val.lerp(&other_val, scalar)))
+                EaseValue(Val::Percent(Lerp::lerp(&self_val, &other_val, scalar)))
             }
             (Val::Px(self_val), Val::Px(other_val)) => {
-                EaseValue(Val::Px(self_val.lerp(&other_val, scalar)))
+                EaseValue(Val::Px(Lerp::lerp(&self_val, &other_val, scalar)))
             }
             _ => EaseValue(self.0),
         }


### PR DESCRIPTION
Uses trait method disambiguation to prefer using the Lerp libraries `lerp` method until the new f32::lerp is stabilized

> Kinda wish I had thought of this solution the first time I encountered this problem, I would have been able to fix it earlier and use this library in a game jam.